### PR TITLE
break up and reconstitute overlarge payloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "debug": "^3.1.0",
+    "lodash": "4.17.10",
     "notepack.io": "^2.1.3",
     "pg": "^7.4.3",
     "socket.io-adapter": "~1.1.0",


### PR DESCRIPTION
Workaround for 8000 character limit of `pg_notify`.

It's not the recommended way from pg to deal with this problem:
> If binary data or large amounts of information need to be communicated, it's best to put it in a database table and send the key of the record.
(https://www.postgresql.org/docs/9.0/static/sql-notify.html)

but this solution does keep this library as a drop-in replacement for the redis version, and there's something to be said for that.

This is working for me. If you're interested to pull this in but want me to refactor to eschew lodash or add tests etc I could carve out some more time to do so.