### PR TITLE
prevent memory leak in chunk reassembler

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,10 +142,10 @@ function adapter(uri, opts) {
         for (var i = 0; i < chunks.length; i++) {
           var header = _.padEnd('_chunk_' + payloadid + '_' + i + '_' + chunks.length, 50);
           var chunk = header + chunks[i];
-          pub.query('SELECT pg_notify('socketio', $1::TEXT)', [JSON.stringify([channel, chunk])]);
+          pub.query('SELECT pg_notify(\'socketio\', $1::TEXT)', [JSON.stringify([channel, chunk])]);
         }
       } else {
-        pub.query('SELECT pg_notify('socketio', $1::TEXT)', [JSON.stringify([channel, payload])]);
+        pub.query('SELECT pg_notify(\'socketio\', $1::TEXT)', [JSON.stringify([channel, payload])]);
       }
     };
 

--- a/index.js
+++ b/index.js
@@ -117,6 +117,13 @@ function adapter(uri, opts) {
         var chunkIndex = _.parseInt(header[3]);
         if (!rechunker[payloadid]) {
           rechunker[payloadid] = [];
+          setTimeout(function () {
+            // no reason why the entire payload should not have arrived within a minute.
+            // prevent memory leak
+            if (rechunker[payloadid]) {
+              delete rechunker[payloadid];
+            }
+          }, 60000);
         }
         var data = payload[1].substring(50);
         rechunker[payloadid][chunkIndex] = data;


### PR DESCRIPTION
I'm not sure if this precaution is at all critical; it's unlikely that any chunks would get dropped along the way. Even so, the process might be running for a long time and it's a good idea to clear out any detritus that builds up.